### PR TITLE
Correções rápidas: ambiente, testes, a11y e build (ganho alto / esforço baixo)

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -39,16 +39,17 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "2MB",
-                  "maximumError": "5MB"
+                  "maximumWarning": "500kB",
+                  "maximumError": "1MB"
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "6kB",
-                  "maximumError": "10kB"
+                  "maximumWarning": "4kB",
+                  "maximumError": "8kB"
                 }
               ],
               "outputHashing": "all",
+              "sourceMap": true,
               "fileReplacements": [
                 {
                   "replace": "src/environments/environment.ts",

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -6,5 +6,3 @@
   <!--AQUI VAI SER RENDERIZADO AS NOSSAS VIEWS/COMPONENTS-->
   <router-outlet></router-outlet>
 </div>
-
-<app-error-msg></app-error-msg>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -34,4 +34,11 @@ describe('AppComponent', () => {
     const compiled = fixture.debugElement.nativeElement;
     expect(compiled.querySelector('.navbar-brand').textContent).toContain('Crud UF - Angular/Java');
   });
+
+  it('should not render an orphan app-error-msg (each page owns its own instance)', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    const compiled = fixture.debugElement.nativeElement;
+    expect(compiled.querySelector('app-error-msg')).toBeNull();
+  });
 });

--- a/src/app/services/estado.service.spec.ts
+++ b/src/app/services/estado.service.spec.ts
@@ -1,12 +1,81 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 import { EstadoService } from './estado.service';
+import { Estado } from '../interfaces/estado';
+import { environment } from '../../environments/environment';
 
 describe('EstadoService', () => {
-  beforeEach(() => TestBed.configureTestingModule({}));
+  let service: EstadoService;
+  let httpMock: HttpTestingController;
+
+  const estado: Estado = { id: 1, sigla: 'SP', nome: 'São Paulo' } as Estado;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
+    service = TestBed.inject(EstadoService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
 
   it('should be created', () => {
-    const service: EstadoService = TestBed.inject(EstadoService);
     expect(service).toBeTruthy();
+  });
+
+  it('getListaEstados should GET the list of estados', () => {
+    service.getListaEstados().subscribe(result => {
+      expect(result).toEqual([estado]);
+    });
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/estado/`);
+    expect(req.request.method).toBe('GET');
+    req.flush([estado]);
+  });
+
+  it('getEstado should GET a single estado by id', () => {
+    service.getEstado(1).subscribe(result => {
+      expect(result).toEqual(estado);
+    });
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/estado/1`);
+    expect(req.request.method).toBe('GET');
+    req.flush(estado);
+  });
+
+  it('addEstado should POST the estado', () => {
+    service.addEstado(estado).subscribe(result => {
+      expect(result).toEqual(estado);
+    });
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/estado/`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(estado);
+    req.flush(estado);
+  });
+
+  it('atualizaEstado should PUT the estado', () => {
+    service.atualizaEstado(estado).subscribe(result => {
+      expect(result).toEqual(estado);
+    });
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/estado/`);
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body).toEqual(estado);
+    req.flush(estado);
+  });
+
+  it('deletaEstado should DELETE by id and not require a body in the response', () => {
+    service.deletaEstado(1).subscribe(result => {
+      expect(result).toBeNull();
+    });
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/estado/1`);
+    expect(req.request.method).toBe('DELETE');
+    req.flush(null, { status: 204, statusText: 'No Content' });
   });
 });

--- a/src/app/services/estado.service.ts
+++ b/src/app/services/estado.service.ts
@@ -31,8 +31,8 @@ export class EstadoService {
     return this.http.put<Estado>(url, estado);
   }
 
-  deletaEstado(id: number): Observable<Estado> {
+  deletaEstado(id: number): Observable<void> {
     const url = `${environment.apiUrl}/estado/${id}`;
-    return this.http.delete<Estado>(url);
+    return this.http.delete<void>(url);
   }
 }

--- a/src/environments/environment.prod.spec.ts
+++ b/src/environments/environment.prod.spec.ts
@@ -1,0 +1,11 @@
+import { environment } from './environment.prod';
+
+describe('environment.prod', () => {
+  it('should not point apiUrl at a local development host', () => {
+    expect(environment.apiUrl).not.toMatch(/localhost|127\.0\.0\.1/);
+  });
+
+  it('should use a relative apiUrl so it works behind any production host/reverse proxy', () => {
+    expect(environment.apiUrl).toBe('/api');
+  });
+});

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
-  apiUrl: 'http://localhost:4200/',
+  apiUrl: '/api',
   production: true
 };

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="pt-BR">
 <head>
   <meta charset="utf-8">
   <title>ClienteEstado</title>


### PR DESCRIPTION
## Resumo

Implementa os itens de **ganho alto / esforço baixo** identificados na revisão do projeto pós-migração para Angular 21, feitos com TDD onde fazia sentido (service HTTP e template).

- **`environment.prod.ts`**: `apiUrl` apontava para `http://localhost:4200/`, que só funciona com o `ng serve` local. Trocado para `/api` (relativo), funcionando atrás de qualquer proxy reverso em produção. Teste de regressão adicionado.
- **`app.component.html`**: removida instância órfã de `<app-error-msg>` no root — nunca recebia erro (cada página já renderiza a sua própria via `@ViewChild`). Teste adicionado garantindo que não seja renderizada.
- **`estado.service.ts`**: `deletaEstado()` estava tipado como `Observable<Estado>`, mas uma resposta DELETE não tem corpo e nenhum chamador usa o valor emitido — corrigido para `Observable<void>`. Aproveitado para expandir `estado.service.spec.ts` de um único smoke test para cobertura real com `HttpClientTestingModule` (verbo HTTP, URL e payload de cada método).
- **`angular.json`**: habilitado `sourceMap` em produção (antes só existia em dev, dificultando debug de erros reais) e reduzidos os budgets de bundle de 2MB/5MB para 500kB/1MB (build atual: ~354kB), para que regressões de tamanho futuras sejam sinalizadas.
- **`index.html`**: `lang="en"` corrigido para `lang="pt-BR"` — todo o conteúdo da aplicação é em português.

## Test plan

- [x] `ng test` — 8 arquivos, 17 testes, todos passando
- [x] `ng build --configuration production` — build bem-sucedido, dentro do novo budget (354kB / 500kB), `.map` gerado para os 3 bundles principais
- [x] Verificado manualmente que `dist/` não foi commitado

🤖 Generated with [Claude Code](https://claude.com/claude-code)