### PR TITLE
Confirma exclusão de estado e mostra indicador de carregamento

### DIFF
--- a/src/app/compartilhado/spinner/spinner.component.html
+++ b/src/app/compartilhado/spinner/spinner.component.html
@@ -1,0 +1,4 @@
+<div class="text-center my-3" role="status">
+  <div class="spinner-border" aria-hidden="true"></div>
+  <span class="visually-hidden">Carregando...</span>
+</div>

--- a/src/app/compartilhado/spinner/spinner.component.ts
+++ b/src/app/compartilhado/spinner/spinner.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-spinner',
+  templateUrl: './spinner.component.html',
+})
+export class SpinnerComponent {}

--- a/src/app/paginas/editar-estado/editar-estado.component.html
+++ b/src/app/paginas/editar-estado/editar-estado.component.html
@@ -5,7 +5,10 @@
       <div class="card">
         <div class="card-header">Editar</div>
         <div class="card-body">
-          @if (estado) {
+          @if (carregando) {
+            <app-spinner></app-spinner>
+          }
+          @if (!carregando && estado) {
             <app-form-estado
               [estado]="estado"
               (outputEstado)="atualizaEstado($event)"

--- a/src/app/paginas/editar-estado/editar-estado.component.spec.ts
+++ b/src/app/paginas/editar-estado/editar-estado.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Router, provideRouter } from '@angular/router';
-import { Observable, of, throwError } from 'rxjs';
+import { Observable, Subject, of, throwError } from 'rxjs';
 
 import { EditarEstadoComponent } from './editar-estado.component';
 import { EstadoService } from 'src/app/services/estado.service';
@@ -71,5 +71,30 @@ describe('EditarEstadoComponent', () => {
     component.atualizaEstado(estado);
 
     expect(component.errorMsgComponent().error).toBe('Nome inválido.');
+  });
+
+  it('should show a loading indicator while fetching the estado', async () => {
+    const subject = new Subject<Estado>();
+    const { component, fixture } = await setup(subject);
+
+    expect(component.carregando).toBe(true);
+    const compiled: HTMLElement = fixture.debugElement.nativeElement;
+    expect(compiled.querySelector('app-spinner')).toBeTruthy();
+
+    subject.next(estado);
+    fixture.detectChanges();
+
+    expect(component.carregando).toBe(false);
+    expect(compiled.querySelector('app-spinner')).toBeFalsy();
+  });
+
+  it('should hide the loading indicator when loading the estado fails', async () => {
+    const { component } = await setup(
+      throwError(
+        () => new HttpErrorResponse({ error: { message: 'Estado não encontrado.' }, status: 404 }),
+      ),
+    );
+
+    expect(component.carregando).toBe(false);
   });
 });

--- a/src/app/paginas/editar-estado/editar-estado.component.ts
+++ b/src/app/paginas/editar-estado/editar-estado.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Estado } from 'src/app/interfaces/estado';
 import { ErrorMsgComponent } from 'src/app/compartilhado/error-msg/error-msg.component';
+import { SpinnerComponent } from 'src/app/compartilhado/spinner/spinner.component';
 import { EstadoService } from 'src/app/services/estado.service';
 import { extraiMensagemErro } from 'src/app/compartilhado/erro/extrai-mensagem-erro';
 import { FormEstadoComponent } from 'src/app/compartilhado/form-estado/form-estado.component';
@@ -11,7 +12,7 @@ import { FormEstadoComponent } from 'src/app/compartilhado/form-estado/form-esta
   selector: 'app-editar-estado',
   templateUrl: './editar-estado.component.html',
   styleUrls: ['./editar-estado.component.scss'],
-  imports: [ErrorMsgComponent, FormEstadoComponent],
+  imports: [ErrorMsgComponent, SpinnerComponent, FormEstadoComponent],
 })
 export class EditarEstadoComponent implements OnInit {
   private estadoService = inject(EstadoService);
@@ -19,6 +20,7 @@ export class EditarEstadoComponent implements OnInit {
   private router = inject(Router);
 
   estado?: Estado;
+  carregando = true;
   readonly errorMsgComponent = viewChild.required(ErrorMsgComponent);
 
   ngOnInit() {
@@ -26,10 +28,15 @@ export class EditarEstadoComponent implements OnInit {
   }
 
   getEstado(id: number) {
+    this.carregando = true;
     this.estadoService.getEstado(id).subscribe({
-      next: (estado) => (this.estado = estado),
+      next: (estado) => {
+        this.estado = estado;
+        this.carregando = false;
+      },
       error: (error: HttpErrorResponse) => {
         this.errorMsgComponent().setError(extraiMensagemErro(error, 'Falha ao buscar estado.'));
+        this.carregando = false;
       },
     });
   }

--- a/src/app/paginas/lista-estado/lista-estado.component.html
+++ b/src/app/paginas/lista-estado/lista-estado.component.html
@@ -13,12 +13,15 @@
   <div class="card">
     <div class="card-header">Estados</div>
     <div class="card-body">
-      @if (!existemEstados()) {
+      @if (carregando) {
+        <app-spinner></app-spinner>
+      }
+      @if (!carregando && !existemEstados()) {
         <div>
           <p class="text-center text-muted">Nenhum estado cadastrado.</p>
         </div>
       }
-      @if (existemEstados()) {
+      @if (!carregando && existemEstados()) {
         <table class="table table-bordered text-center">
           <thead>
             <tr>

--- a/src/app/paginas/lista-estado/lista-estado.component.spec.ts
+++ b/src/app/paginas/lista-estado/lista-estado.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpErrorResponse } from '@angular/common/http';
 import { provideRouter } from '@angular/router';
-import { Observable, of, throwError } from 'rxjs';
+import { Observable, Subject, of, throwError } from 'rxjs';
 
 import { ListaEstadoComponent } from './lista-estado.component';
 import { EstadoService } from 'src/app/services/estado.service';
@@ -13,6 +13,10 @@ describe('ListaEstadoComponent', () => {
     getListaEstados: ReturnType<typeof vi.fn>;
     deletaEstado: ReturnType<typeof vi.fn>;
   };
+
+  beforeEach(() => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+  });
 
   async function setup(getListaEstadosReturn: Observable<Estado[]> = of(estados)) {
     estadoService = {
@@ -82,5 +86,51 @@ describe('ListaEstadoComponent', () => {
     component.deletaEstado(1);
 
     expect(component.errorMsgComponent().error).toBe('Estado possui vínculos.');
+  });
+
+  it('should ask for confirmation before deleting an estado', async () => {
+    const { component } = await setup();
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    estadoService.deletaEstado.mockReturnValue(of(undefined));
+
+    component.deletaEstado(1);
+
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(estadoService.deletaEstado).toHaveBeenCalledWith(1);
+  });
+
+  it('should not delete the estado when the confirmation is cancelled', async () => {
+    const { component } = await setup();
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+
+    component.deletaEstado(1);
+
+    expect(estadoService.deletaEstado).not.toHaveBeenCalled();
+  });
+
+  it('should show a loading indicator while fetching the list', async () => {
+    const subject = new Subject<Estado[]>();
+    const { component, fixture } = await setup(subject);
+
+    expect(component.carregando).toBe(true);
+    const compiled: HTMLElement = fixture.debugElement.nativeElement;
+    expect(compiled.querySelector('app-spinner')).toBeTruthy();
+    expect(compiled.textContent).not.toContain('Nenhum estado cadastrado.');
+
+    subject.next(estados);
+    fixture.detectChanges();
+
+    expect(component.carregando).toBe(false);
+    expect(compiled.querySelector('app-spinner')).toBeFalsy();
+  });
+
+  it('should hide the loading indicator when loading the list fails', async () => {
+    const { component } = await setup(
+      throwError(
+        () => new HttpErrorResponse({ error: { message: 'Serviço indisponível.' }, status: 503 }),
+      ),
+    );
+
+    expect(component.carregando).toBe(false);
   });
 });

--- a/src/app/paginas/lista-estado/lista-estado.component.ts
+++ b/src/app/paginas/lista-estado/lista-estado.component.ts
@@ -4,6 +4,7 @@ import { DatePipe } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Estado } from 'src/app/interfaces/estado';
 import { ErrorMsgComponent } from 'src/app/compartilhado/error-msg/error-msg.component';
+import { SpinnerComponent } from 'src/app/compartilhado/spinner/spinner.component';
 import { EstadoService } from 'src/app/services/estado.service';
 import { extraiMensagemErro } from 'src/app/compartilhado/erro/extrai-mensagem-erro';
 
@@ -11,12 +12,13 @@ import { extraiMensagemErro } from 'src/app/compartilhado/erro/extrai-mensagem-e
   selector: 'app-lista-estado',
   templateUrl: './lista-estado.component.html',
   styleUrls: ['./lista-estado.component.scss'],
-  imports: [ErrorMsgComponent, RouterLink, DatePipe],
+  imports: [ErrorMsgComponent, SpinnerComponent, RouterLink, DatePipe],
 })
 export class ListaEstadoComponent implements OnInit {
   private estadoService = inject(EstadoService);
 
   public estados: Estado[] = [];
+  public carregando = true;
   readonly errorMsgComponent = viewChild.required(ErrorMsgComponent);
 
   ngOnInit() {
@@ -24,17 +26,23 @@ export class ListaEstadoComponent implements OnInit {
   }
 
   getListaEstados() {
+    this.carregando = true;
     this.estadoService.getListaEstados().subscribe({
       next: (estados: Estado[]) => {
         this.estados = estados;
+        this.carregando = false;
       },
       error: (error: HttpErrorResponse) => {
         this.errorMsgComponent().setError(extraiMensagemErro(error, 'Falha ao buscar estados.'));
+        this.carregando = false;
       },
     });
   }
 
   deletaEstado(id: number) {
+    if (!window.confirm('Tem certeza que deseja excluir este estado?')) {
+      return;
+    }
     this.estadoService.deletaEstado(id).subscribe({
       next: () => {
         this.getListaEstados();


### PR DESCRIPTION
## Resumo
- Adiciona confirmação (`window.confirm`) antes de excluir um estado na listagem, evitando que um clique acidental no botão "X" apague um registro sem aviso.
- Adiciona um spinner (`app-spinner`, compartilhado) enquanto a lista de estados e o formulário de edição buscam dados, evitando que a mensagem "Nenhum estado cadastrado" ou o formulário vazio pisquem antes da resposta chegar.

## Test plan
- [x] Testes unitários escritos primeiro (TDD) cobrindo: confirmação aceita/cancelada, exibição/ocultação do spinner em sucesso e erro, tanto na lista quanto na edição.
- [x] `ng test` — 46 testes passando.
- [x] `ng lint` — sem problemas.
- [ ] Verificação manual no navegador (não foi possível neste ambiente por falta do Chromium do Playwright).

🤖 Generated with [Claude Code](https://claude.com/claude-code)