### PR TITLE
fix: previne duplo submit/clique em salvar e excluir estado

### DIFF
--- a/src/app/compartilhado/erro/subscreve-com-processando.ts
+++ b/src/app/compartilhado/erro/subscreve-com-processando.ts
@@ -4,22 +4,22 @@ import { Observable } from 'rxjs';
 import { ErrorMsgComponent } from '../error-msg/error-msg.component';
 import { extraiMensagemErro } from './extrai-mensagem-erro';
 
-export function subscreveComCarregamento<T>(
+export function subscreveComProcessando<T>(
   observable: Observable<T>,
-  carregando: WritableSignal<boolean>,
+  processando: WritableSignal<boolean>,
   errorMsgComponent: ErrorMsgComponent,
   mensagemErro: string,
   onSuccess: (valor: T) => void,
 ): void {
-  carregando.set(true);
+  processando.set(true);
   observable.subscribe({
     next: (valor) => {
       onSuccess(valor);
-      carregando.set(false);
+      processando.set(false);
     },
     error: (error: HttpErrorResponse) => {
       errorMsgComponent.setError(extraiMensagemErro(error, mensagemErro));
-      carregando.set(false);
+      processando.set(false);
     },
   });
 }

--- a/src/app/compartilhado/form-estado/form-estado.component.html
+++ b/src/app/compartilhado/form-estado/form-estado.component.html
@@ -46,6 +46,12 @@
     </div>
   </div>
   <div class="col-sm-12">
-    <button class="btn btn-primary float-right" type="submit" [disabled]="!f.valid">Salvar</button>
+    <button
+      class="btn btn-primary float-right"
+      type="submit"
+      [disabled]="!f.valid || desabilitado()"
+    >
+      Salvar
+    </button>
   </div>
 </form>

--- a/src/app/compartilhado/form-estado/form-estado.component.spec.ts
+++ b/src/app/compartilhado/form-estado/form-estado.component.spec.ts
@@ -56,4 +56,15 @@ describe('FormEstadoComponent', () => {
 
     expect(sigla.getAttribute('aria-invalid')).toBe('true');
   });
+
+  it('should disable the submit button when desabilitado is true, even with a valid form', () => {
+    fixture.componentRef.setInput('estado', { sigla: 'SP', nome: 'São Paulo' });
+    fixture.componentRef.setInput('desabilitado', true);
+    fixture.detectChanges();
+
+    const compiled: HTMLElement = fixture.debugElement.nativeElement;
+    const submitButton: HTMLButtonElement = compiled.querySelector('button[type="submit"]')!;
+
+    expect(submitButton.disabled).toBe(true);
+  });
 });

--- a/src/app/compartilhado/form-estado/form-estado.component.ts
+++ b/src/app/compartilhado/form-estado/form-estado.component.ts
@@ -10,6 +10,7 @@ import { FormsModule } from '@angular/forms';
 })
 export class FormEstadoComponent {
   readonly estado = input<Estado>({} as Estado);
+  readonly desabilitado = input(false);
   readonly outputEstado = output<Estado>();
 
   onSubmit() {

--- a/src/app/paginas/criar-estado/criar-estado.component.html
+++ b/src/app/paginas/criar-estado/criar-estado.component.html
@@ -4,7 +4,10 @@
     <div class="card">
       <div class="card-header">Criar</div>
       <div class="card-body">
-        <app-form-estado (outputEstado)="addEstado($event)"></app-form-estado>
+        <app-form-estado
+          [desabilitado]="salvando()"
+          (outputEstado)="addEstado($event)"
+        ></app-form-estado>
       </div>
     </div>
   </div>

--- a/src/app/paginas/criar-estado/criar-estado.component.spec.ts
+++ b/src/app/paginas/criar-estado/criar-estado.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Router, provideRouter } from '@angular/router';
-import { of, throwError } from 'rxjs';
+import { Subject, of, throwError } from 'rxjs';
 
 import { CriarEstadoComponent } from './criar-estado.component';
 import { EstadoService } from '../../services/estado.service';
@@ -63,5 +63,28 @@ describe('CriarEstadoComponent', () => {
     component.addEstado(estado);
 
     expect(component.errorMsgComponent().error()).toBe('Falha ao adicionar estado.');
+  });
+
+  it('should mark salvando while the create request is in flight, guarding against double submission', () => {
+    const subject = new Subject<Estado>();
+    estadoService.addEstado.mockReturnValue(subject);
+
+    component.addEstado(estado);
+
+    expect(component.salvando()).toBe(true);
+
+    subject.next(estado);
+
+    expect(component.salvando()).toBe(false);
+  });
+
+  it('should clear salvando when creation fails', () => {
+    estadoService.addEstado.mockReturnValue(
+      throwError(() => new HttpErrorResponse({ status: 500 })),
+    );
+
+    component.addEstado(estado);
+
+    expect(component.salvando()).toBe(false);
   });
 });

--- a/src/app/paginas/criar-estado/criar-estado.component.ts
+++ b/src/app/paginas/criar-estado/criar-estado.component.ts
@@ -1,10 +1,9 @@
-import { Component, viewChild, inject } from '@angular/core';
+import { Component, viewChild, inject, signal } from '@angular/core';
 import { Router } from '@angular/router';
-import { HttpErrorResponse } from '@angular/common/http';
 import { Estado } from '../../interfaces/estado';
 import { ErrorMsgComponent } from '../../compartilhado/error-msg/error-msg.component';
 import { EstadoService } from '../../services/estado.service';
-import { extraiMensagemErro } from '../../compartilhado/erro/extrai-mensagem-erro';
+import { subscreveComProcessando } from '../../compartilhado/erro/subscreve-com-processando';
 import { FormEstadoComponent } from '../../compartilhado/form-estado/form-estado.component';
 
 @Component({
@@ -18,15 +17,15 @@ export class CriarEstadoComponent {
   private router = inject(Router);
 
   readonly errorMsgComponent = viewChild.required(ErrorMsgComponent);
+  salvando = signal(false);
 
   addEstado(estado: Estado) {
-    this.estadoService.addEstado(estado).subscribe({
-      next: () => {
-        this.router.navigateByUrl('/');
-      },
-      error: (error: HttpErrorResponse) => {
-        this.errorMsgComponent().setError(extraiMensagemErro(error, 'Falha ao adicionar estado.'));
-      },
-    });
+    subscreveComProcessando(
+      this.estadoService.addEstado(estado),
+      this.salvando,
+      this.errorMsgComponent(),
+      'Falha ao adicionar estado.',
+      () => this.router.navigateByUrl('/'),
+    );
   }
 }

--- a/src/app/paginas/editar-estado/editar-estado.component.html
+++ b/src/app/paginas/editar-estado/editar-estado.component.html
@@ -11,6 +11,7 @@
           @if (!carregando() && estado()) {
             <app-form-estado
               [estado]="estado()!"
+              [desabilitado]="salvando()"
               (outputEstado)="atualizaEstado($event)"
             ></app-form-estado>
           }

--- a/src/app/paginas/editar-estado/editar-estado.component.spec.ts
+++ b/src/app/paginas/editar-estado/editar-estado.component.spec.ts
@@ -97,4 +97,29 @@ describe('EditarEstadoComponent', () => {
 
     expect(component.carregando()).toBe(false);
   });
+
+  it('should mark salvando while the update request is in flight, guarding against double submission', async () => {
+    const { component } = await setup();
+    const subject = new Subject<Estado>();
+    estadoService.atualizaEstado.mockReturnValue(subject);
+
+    component.atualizaEstado(estado);
+
+    expect(component.salvando()).toBe(true);
+
+    subject.next(estado);
+
+    expect(component.salvando()).toBe(false);
+  });
+
+  it('should clear salvando when updating fails', async () => {
+    const { component } = await setup();
+    estadoService.atualizaEstado.mockReturnValue(
+      throwError(() => new HttpErrorResponse({ status: 500 })),
+    );
+
+    component.atualizaEstado(estado);
+
+    expect(component.salvando()).toBe(false);
+  });
 });

--- a/src/app/paginas/editar-estado/editar-estado.component.ts
+++ b/src/app/paginas/editar-estado/editar-estado.component.ts
@@ -1,12 +1,10 @@
 import { Component, OnInit, viewChild, inject, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { HttpErrorResponse } from '@angular/common/http';
 import { Estado } from '../../interfaces/estado';
 import { ErrorMsgComponent } from '../../compartilhado/error-msg/error-msg.component';
 import { SpinnerComponent } from '../../compartilhado/spinner/spinner.component';
 import { EstadoService } from '../../services/estado.service';
-import { extraiMensagemErro } from '../../compartilhado/erro/extrai-mensagem-erro';
-import { subscreveComCarregamento } from '../../compartilhado/erro/subscreve-com-carregamento';
+import { subscreveComProcessando } from '../../compartilhado/erro/subscreve-com-processando';
 import { FormEstadoComponent } from '../../compartilhado/form-estado/form-estado.component';
 
 @Component({
@@ -22,6 +20,7 @@ export class EditarEstadoComponent implements OnInit {
 
   estado = signal<Estado | undefined>(undefined);
   carregando = signal(true);
+  salvando = signal(false);
   readonly errorMsgComponent = viewChild.required(ErrorMsgComponent);
 
   ngOnInit() {
@@ -29,7 +28,7 @@ export class EditarEstadoComponent implements OnInit {
   }
 
   getEstado(id: number) {
-    subscreveComCarregamento(
+    subscreveComProcessando(
       this.estadoService.getEstado(id),
       this.carregando,
       this.errorMsgComponent(),
@@ -39,13 +38,12 @@ export class EditarEstadoComponent implements OnInit {
   }
 
   atualizaEstado(estado: Estado) {
-    this.estadoService.atualizaEstado(estado).subscribe({
-      next: () => {
-        this.router.navigateByUrl('/');
-      },
-      error: (error: HttpErrorResponse) => {
-        this.errorMsgComponent().setError(extraiMensagemErro(error, 'Falha ao atualizar estado.'));
-      },
-    });
+    subscreveComProcessando(
+      this.estadoService.atualizaEstado(estado),
+      this.salvando,
+      this.errorMsgComponent(),
+      'Falha ao atualizar estado.',
+      () => this.router.navigateByUrl('/'),
+    );
   }
 }

--- a/src/app/paginas/lista-estado/lista-estado.component.html
+++ b/src/app/paginas/lista-estado/lista-estado.component.html
@@ -52,6 +52,7 @@
                     type="button"
                     class="btn btn-danger btn-sm ml-1"
                     [attr.aria-label]="'Excluir ' + estado.sigla"
+                    [disabled]="excluindo()"
                     (click)="deletaEstado(estado.id)"
                   >
                     X

--- a/src/app/paginas/lista-estado/lista-estado.component.spec.ts
+++ b/src/app/paginas/lista-estado/lista-estado.component.spec.ts
@@ -108,6 +108,37 @@ describe('ListaEstadoComponent', () => {
     expect(estadoService.deletaEstado).not.toHaveBeenCalled();
   });
 
+  it('should disable the exclude buttons while a deletion is in flight, guarding against double clicks', async () => {
+    const { component, fixture } = await setup();
+    const subject = new Subject<void>();
+    estadoService.deletaEstado.mockReturnValue(subject);
+
+    component.deletaEstado(1);
+    fixture.detectChanges();
+
+    expect(component.excluindo()).toBe(true);
+    const compiled: HTMLElement = fixture.debugElement.nativeElement;
+    const excluir: HTMLButtonElement = compiled.querySelector('button.btn-danger')!;
+    expect(excluir.disabled).toBe(true);
+
+    estadoService.getListaEstados.mockReturnValue(of(estados));
+    subject.next();
+    fixture.detectChanges();
+
+    expect(component.excluindo()).toBe(false);
+  });
+
+  it('should re-enable the exclude buttons when deletion fails', async () => {
+    const { component } = await setup();
+    estadoService.deletaEstado.mockReturnValue(
+      throwError(() => new HttpErrorResponse({ status: 500 })),
+    );
+
+    component.deletaEstado(1);
+
+    expect(component.excluindo()).toBe(false);
+  });
+
   it('should show a loading indicator while fetching the list', async () => {
     const subject = new Subject<Estado[]>();
     const { component, fixture } = await setup(subject);

--- a/src/app/paginas/lista-estado/lista-estado.component.ts
+++ b/src/app/paginas/lista-estado/lista-estado.component.ts
@@ -1,13 +1,11 @@
 import { Component, OnInit, viewChild, inject, signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { DatePipe } from '@angular/common';
-import { HttpErrorResponse } from '@angular/common/http';
 import { Estado } from '../../interfaces/estado';
 import { ErrorMsgComponent } from '../../compartilhado/error-msg/error-msg.component';
 import { SpinnerComponent } from '../../compartilhado/spinner/spinner.component';
 import { EstadoService } from '../../services/estado.service';
-import { extraiMensagemErro } from '../../compartilhado/erro/extrai-mensagem-erro';
-import { subscreveComCarregamento } from '../../compartilhado/erro/subscreve-com-carregamento';
+import { subscreveComProcessando } from '../../compartilhado/erro/subscreve-com-processando';
 
 @Component({
   selector: 'app-lista-estado',
@@ -20,6 +18,7 @@ export class ListaEstadoComponent implements OnInit {
 
   public estados = signal<Estado[]>([]);
   public carregando = signal(true);
+  public excluindo = signal(false);
   readonly errorMsgComponent = viewChild.required(ErrorMsgComponent);
 
   ngOnInit() {
@@ -27,7 +26,7 @@ export class ListaEstadoComponent implements OnInit {
   }
 
   getListaEstados() {
-    subscreveComCarregamento(
+    subscreveComProcessando(
       this.estadoService.getListaEstados(),
       this.carregando,
       this.errorMsgComponent(),
@@ -40,14 +39,13 @@ export class ListaEstadoComponent implements OnInit {
     if (!window.confirm('Tem certeza que deseja excluir este estado?')) {
       return;
     }
-    this.estadoService.deletaEstado(id).subscribe({
-      next: () => {
-        this.getListaEstados();
-      },
-      error: (error: HttpErrorResponse) => {
-        this.errorMsgComponent().setError(extraiMensagemErro(error, 'Falha ao deletar estado.'));
-      },
-    });
+    subscreveComProcessando(
+      this.estadoService.deletaEstado(id),
+      this.excluindo,
+      this.errorMsgComponent(),
+      'Falha ao deletar estado.',
+      () => this.getListaEstados(),
+    );
   }
 
   existemEstados(): boolean {


### PR DESCRIPTION
## Contexto

Nas telas de criar/editar estado e na lista de estados, `addEstado`, `atualizaEstado` e `deletaEstado` não tinham nenhuma proteção contra duplo clique/duplo submit: se o usuário clicasse duas vezes em "Salvar" ou "X" (excluir) antes da resposta do backend, duas requisições eram disparadas sem aviso.

## O que este PR faz

1. **`FormEstadoComponent`** ganha o input `desabilitado` (default `false`), que desabilita o botão "Salvar" além da validação de formulário já existente.
2. **`CriarEstadoComponent`** e **`EditarEstadoComponent`** ganham o signal `salvando`, setado durante `addEstado`/`atualizaEstado` e passado para `[desabilitado]` do `app-form-estado`.
3. **`ListaEstadoComponent`** ganha o signal `excluindo`, setado durante `deletaEstado`, desabilitando os botões "X" (excluir) da tabela enquanto a exclusão está em andamento.
4. **`subscreveComCarregamento` → `subscreveComProcessando`**: o helper extraído em #40 para o padrão carregando/erro agora também é reaproveitado para `salvando`/`excluindo`, então foi renomeado para refletir que cobre qualquer estado de "operação em andamento", não só carregamento de dados.

## Validação local

- `npm test` — 53/53 testes passando (7 novos cobrindo o `salvando`/`excluindo` e o input `desabilitado`) ✅
- `npm run lint` ✅
- `tsc --noEmit` (app e specs) ✅

## Test plan

- [x] Testes automatizados cobrindo: botão desabilitado durante requisição, reabilitado em caso de erro, sinal limpo após sucesso
- [x] Revisar app rodando localmente (clicar duas vezes em Salvar/Excluir e confirmar que só uma requisição é enviada)
