### PR TITLE
fix: container em criar-estado + refactors (service e mocks e2e)

### DIFF
--- a/e2e/criar-estado.spec.ts
+++ b/e2e/criar-estado.spec.ts
@@ -1,17 +1,9 @@
 import { test, expect } from '@playwright/test';
+import { mockAddEstado, mockErro } from './fixtures/estados';
 
 test.describe('Criar estado', () => {
   test('cria um novo estado e volta para a lista', async ({ page }) => {
-    await page.route('**/api/estado/', (route) => {
-      if (route.request().method() !== 'POST') {
-        return route.fallback();
-      }
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: route.request().postData() ?? '{}',
-      });
-    });
+    await mockAddEstado(page);
 
     await page.goto('/estado/criar');
     await page.locator('#sigla').fill('MG');
@@ -33,12 +25,7 @@ test.describe('Criar estado', () => {
   });
 
   test('exibe mensagem de erro quando a criação falha', async ({ page }) => {
-    await page.route('**/api/estado/', (route) => {
-      if (route.request().method() !== 'POST') {
-        return route.fallback();
-      }
-      return route.fulfill({ status: 500, contentType: 'application/json', body: '{}' });
-    });
+    await mockErro(page, '**/api/estado/', 500, 'POST');
 
     await page.goto('/estado/criar');
     await page.locator('#sigla').fill('MG');

--- a/e2e/editar-estado.spec.ts
+++ b/e2e/editar-estado.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { ESTADOS, mockGetEstado } from './fixtures/estados';
+import { ESTADOS, mockGetEstado, mockAtualizaEstado, mockErro } from './fixtures/estados';
 
 test.describe('Editar estado', () => {
   test('preenche o formulário assim que o estado chega de forma assíncrona', async ({ page }) => {
@@ -18,16 +18,7 @@ test.describe('Editar estado', () => {
   test('atualiza o estado e volta para a lista', async ({ page }) => {
     const estado = ESTADOS[0];
     await mockGetEstado(page, estado, 100);
-    await page.route('**/api/estado/', (route) => {
-      if (route.request().method() !== 'PUT') {
-        return route.fallback();
-      }
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: route.request().postData() ?? '{}',
-      });
-    });
+    await mockAtualizaEstado(page);
 
     await page.goto(`/estado/editar/${estado.id}`);
     await expect(page.locator('#nome')).toHaveValue(estado.nome);
@@ -39,9 +30,7 @@ test.describe('Editar estado', () => {
   });
 
   test('exibe mensagem de erro quando a busca do estado falha', async ({ page }) => {
-    await page.route('**/api/estado/1', (route) =>
-      route.fulfill({ status: 404, contentType: 'application/json', body: '{}' }),
-    );
+    await mockErro(page, '**/api/estado/1', 404);
 
     await page.goto('/estado/editar/1');
 

--- a/e2e/fixtures/estados.ts
+++ b/e2e/fixtures/estados.ts
@@ -61,3 +61,45 @@ export function mockGetEstado(page: Page, estado: EstadoFixture, delayMs = 300):
     return fulfillDelayed(route, estado, undefined, delayMs);
   });
 }
+
+function mockSalvaEstado(page: Page, method: 'POST' | 'PUT', status = 200): Promise<void> {
+  return page.route('**/api/estado/', (route) => {
+    if (route.request().method() !== method) {
+      return route.fallback();
+    }
+    const body = status === 200 ? (route.request().postData() ?? '{}') : '{}';
+    return route.fulfill({ status, contentType: 'application/json', body });
+  });
+}
+
+export function mockAddEstado(page: Page, status = 200): Promise<void> {
+  return mockSalvaEstado(page, 'POST', status);
+}
+
+export function mockAtualizaEstado(page: Page, status = 200): Promise<void> {
+  return mockSalvaEstado(page, 'PUT', status);
+}
+
+export function mockDeletaEstado(page: Page, id: number, onDelete?: () => void): Promise<void> {
+  return page.route(`**/api/estado/${id}`, (route) => {
+    if (route.request().method() !== 'DELETE') {
+      return route.fallback();
+    }
+    onDelete?.();
+    return route.fulfill({ status: 200 });
+  });
+}
+
+export function mockErro(
+  page: Page,
+  urlPattern: string,
+  status: number,
+  method?: string,
+): Promise<void> {
+  return page.route(urlPattern, (route) => {
+    if (method && route.request().method() !== method) {
+      return route.fallback();
+    }
+    return route.fulfill({ status, contentType: 'application/json', body: '{}' });
+  });
+}

--- a/e2e/lista-estado.spec.ts
+++ b/e2e/lista-estado.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { ESTADOS, mockListaEstados } from './fixtures/estados';
+import { ESTADOS, mockListaEstados, mockDeletaEstado, mockErro } from './fixtures/estados';
 
 test.describe('Lista de estados', () => {
   test('exibe os estados assim que a resposta assíncrona chega, após o primeiro ciclo de renderização', async ({
@@ -28,9 +28,7 @@ test.describe('Lista de estados', () => {
   });
 
   test('exibe mensagem de erro quando a busca falha', async ({ page }) => {
-    await page.route('**/api/estado/', (route) =>
-      route.fulfill({ status: 500, contentType: 'application/json', body: '{}' }),
-    );
+    await mockErro(page, '**/api/estado/', 500);
     await page.goto('/');
 
     await expect(page.getByRole('alert')).toContainText('Falha ao buscar estados.');
@@ -49,13 +47,9 @@ test.describe('Lista de estados', () => {
         body: JSON.stringify(estados),
       });
     });
-    await page.route('**/api/estado/1', (route) => {
-      if (route.request().method() === 'DELETE') {
-        requestedDelete = true;
-        estados = estados.filter((estado) => estado.id !== 1);
-        return route.fulfill({ status: 200 });
-      }
-      return route.fallback();
+    await mockDeletaEstado(page, 1, () => {
+      requestedDelete = true;
+      estados = estados.filter((estado) => estado.id !== 1);
     });
 
     await page.goto('/');

--- a/src/app/paginas/criar-estado/criar-estado.component.html
+++ b/src/app/paginas/criar-estado/criar-estado.component.html
@@ -1,13 +1,15 @@
-<div class="row">
-  <div class="col-md-5 mx-auto">
-    <app-error-msg></app-error-msg>
-    <div class="card">
-      <div class="card-header">Criar</div>
-      <div class="card-body">
-        <app-form-estado
-          [desabilitado]="salvando()"
-          (outputEstado)="addEstado($event)"
-        ></app-form-estado>
+<div class="container mt-3">
+  <div class="row">
+    <div class="col-md-5 mx-auto">
+      <app-error-msg></app-error-msg>
+      <div class="card">
+        <div class="card-header">Criar</div>
+        <div class="card-body">
+          <app-form-estado
+            [desabilitado]="salvando()"
+            (outputEstado)="addEstado($event)"
+          ></app-form-estado>
+        </div>
       </div>
     </div>
   </div>

--- a/src/app/paginas/criar-estado/criar-estado.component.spec.ts
+++ b/src/app/paginas/criar-estado/criar-estado.component.spec.ts
@@ -33,6 +33,11 @@ describe('CriarEstadoComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('should wrap its content in the same container used by the other pages', () => {
+    const compiled: HTMLElement = fixture.debugElement.nativeElement;
+    expect(compiled.querySelector('.container.mt-3')).toBeTruthy();
+  });
+
   it('should navigate to the estado list after successfully creating an estado', () => {
     const router = TestBed.inject(Router);
     const navigateSpy = vi.spyOn(router, 'navigateByUrl').mockResolvedValue(true);

--- a/src/app/services/estado.service.ts
+++ b/src/app/services/estado.service.ts
@@ -9,29 +9,25 @@ import { Observable } from 'rxjs';
 })
 export class EstadoService {
   private http = inject(HttpClient);
+  private readonly baseUrl = `${environment.apiUrl}/estado`;
 
   getListaEstados(): Observable<Estado[]> {
-    const url = `${environment.apiUrl}/estado/`;
-    return this.http.get<Estado[]>(url);
+    return this.http.get<Estado[]>(`${this.baseUrl}/`);
   }
 
   getEstado(id: number): Observable<Estado> {
-    const url = `${environment.apiUrl}/estado/${id}`;
-    return this.http.get<Estado>(url);
+    return this.http.get<Estado>(`${this.baseUrl}/${id}`);
   }
 
   addEstado(estado: Estado): Observable<Estado> {
-    const url = `${environment.apiUrl}/estado/`;
-    return this.http.post<Estado>(url, estado);
+    return this.http.post<Estado>(`${this.baseUrl}/`, estado);
   }
 
   atualizaEstado(estado: Estado): Observable<Estado> {
-    const url = `${environment.apiUrl}/estado/`;
-    return this.http.put<Estado>(url, estado);
+    return this.http.put<Estado>(`${this.baseUrl}/`, estado);
   }
 
   deletaEstado(id: number): Observable<void> {
-    const url = `${environment.apiUrl}/estado/${id}`;
-    return this.http.delete<void>(url);
+    return this.http.delete<void>(`${this.baseUrl}/${id}`);
   }
 }


### PR DESCRIPTION
## Resumo
- Corrige a página de criar estado, que não tinha o wrapper `.container.mt-3` usado pelas demais páginas, causando inconsistência de layout.
- Refatora `EstadoService` para extrair `baseUrl`, reduzindo repetição na montagem das URLs da API.
- Refatora os specs e2e (Playwright), extraindo helpers de mock compartilhados (`mockAddEstado`, `mockAtualizaEstado`, `mockDeletaEstado`, `mockErro`) e removendo duplicação entre os specs de criar, editar e listar estado.

## Plano de teste
- [x] `npm test` (unit tests) passando
- [x] `npm run e2e` (Playwright) passando
- [x] Conferir visualmente que a página `/estado/criar` está alinhada com as demais páginas